### PR TITLE
feature: improve default push notification behavior

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,6 @@ tags
 
 # End of https://www.toptal.com/developers/gitignore/api/linux,macos,rust,visualstudiocode,vim
 
+# Nix
+/result
+/.direnv

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,123 @@
+{
+  "nodes": {
+    "crane": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-overlay": "rust-overlay"
+      },
+      "locked": {
+        "lastModified": 1666567222,
+        "narHash": "sha256-AVySilLW+eNM409GSIJYsF6wg5NsxK12Ht2DMSYAgO0=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "2ce1a3313e299b0db63b11f94c863af74b0b08ad",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1650374568,
+        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "locked": {
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1685533922,
+        "narHash": "sha256-y4FCQpYafMQ42l1V+NUrMel9RtFtZo59PzdzflKR/lo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "3a70dd92993182f8e514700ccf5b1ae9fc8a3b8d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-23.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "crane": "crane",
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": [
+          "crane",
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "crane",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1666494036,
+        "narHash": "sha256-4mmm+1MBPMD56LMLN9QcEwnfnu41NkA6lDeZGjSrxIw=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "af2e939ba2c7cbb188d06d6650c6353b10b3f2be",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -33,6 +33,7 @@
       {
         packages.default = craneLib.buildPackage ({
           meta = { mainProgram = "fpush"; };
+          cargoExtraArgs = "--all-features";
          } // commonArgs);
 
         devShells = {

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,55 @@
+{
+  description = "Scalable push server for XMPP";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.05";
+    flake-utils.url = "github:numtide/flake-utils";
+    crane = {
+      url = "github:ipetkov/crane";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = { self, nixpkgs, flake-utils, crane }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+        };
+        craneLib = crane.lib.${system};
+
+        commonArgs = {
+          src = craneLib.cleanCargoSource ./.;
+
+          buildInputs = [
+            pkgs.openssl
+          ];
+
+          nativeBuildInputs = [
+            pkgs.pkg-config
+          ];
+        };
+      in
+      {
+        packages.default = craneLib.buildPackage ({
+          meta = { mainProgram = "fpush"; };
+         } // commonArgs);
+
+        devShells = {
+          default = pkgs.mkShell {
+
+            buildInputs = [ ] ++ commonArgs.buildInputs;
+            nativeBuildInputs = builtins.attrValues
+              {
+                inherit (pkgs) cargo rustc nixpkgs-fmt shellcheck rnix-lsp;
+              } ++ [
+              # This is required to prevent a mangled bash shell in nix develop
+              # see: https://discourse.nixos.org/t/interactive-bash-with-nix-develop-flake/15486
+              (pkgs.hiPrio pkgs.bashInteractive)
+
+            ] ++ commonArgs.nativeBuildInputs;
+          };
+        };
+      }
+    );
+}

--- a/fpush-fcm/src/push.rs
+++ b/fpush-fcm/src/push.rs
@@ -4,7 +4,7 @@ use fpush_traits::push::{PushError, PushResult, PushTrait};
 
 use async_trait::async_trait;
 use google_fcm1::{
-    api::{Message, SendMessageRequest},
+    api::{Message, SendMessageRequest, Notification},
     oauth2, FirebaseCloudMessaging,
 };
 use log::{error, warn};
@@ -126,6 +126,16 @@ fn create_push_message(token: String) -> Message {
     Message {
         data: Some(HashMap::new()),
         token: Some(token),
+        notification: Some(create_notification()),
+        ..Default::default()
+    }
+}
+
+#[inline(always)]
+fn create_notification() -> Notification {
+    Notification {
+        body: Some("You have new messages".to_string()),
+        title: Some("Fedi Alpha".to_string()),
         ..Default::default()
     }
 }

--- a/fpush-fcm/src/push.rs
+++ b/fpush-fcm/src/push.rs
@@ -4,7 +4,7 @@ use fpush_traits::push::{PushError, PushResult, PushTrait};
 
 use async_trait::async_trait;
 use google_fcm1::{
-    api::{Message, SendMessageRequest, Notification},
+    api::{Message, SendMessageRequest, Notification, AndroidConfig, AndroidNotification},
     oauth2, FirebaseCloudMessaging,
 };
 use log::{error, warn};
@@ -127,6 +127,9 @@ fn create_push_message(token: String) -> Message {
         data: Some(HashMap::new()),
         token: Some(token),
         notification: Some(create_notification()),
+        // add this to make sure we set the tag to group on Android
+        // so the user only ever sees 1 notification in their drawer
+        android: Some(create_android_config()),
         ..Default::default()
     }
 }
@@ -136,6 +139,22 @@ fn create_notification() -> Notification {
     Notification {
         body: Some("You have new messages".to_string()),
         title: Some("Fedi Alpha".to_string()),
+        ..Default::default()
+    }
+}
+
+#[inline(always)]
+fn create_android_config() -> AndroidConfig {
+    AndroidConfig {
+        notification: Some(create_android_notification()),
+        ..Default::default()
+    }
+}
+
+#[inline(always)]
+fn create_android_notification() -> AndroidNotification {
+    AndroidNotification {
+        tag: Some("new_chat_messages".to_string()),
         ..Default::default()
     }
 }

--- a/fpush-fcm/src/push.rs
+++ b/fpush-fcm/src/push.rs
@@ -4,7 +4,7 @@ use fpush_traits::push::{PushError, PushResult, PushTrait};
 
 use async_trait::async_trait;
 use google_fcm1::{
-    api::{Message, SendMessageRequest, Notification, AndroidConfig, AndroidNotification},
+    api::{Message, SendMessageRequest, Notification, AndroidConfig, AndroidNotification, ApnsConfig},
     oauth2, FirebaseCloudMessaging,
 };
 use log::{error, warn};
@@ -130,6 +130,7 @@ fn create_push_message(token: String) -> Message {
         // add this to make sure we set the tag to group on Android
         // so the user only ever sees 1 notification in their drawer
         android: Some(create_android_config()),
+        apns: Some(create_apns_config()),
         ..Default::default()
     }
 }
@@ -142,6 +143,7 @@ fn create_notification() -> Notification {
         ..Default::default()
     }
 }
+
 
 #[inline(always)]
 fn create_android_config() -> AndroidConfig {
@@ -157,4 +159,19 @@ fn create_android_notification() -> AndroidNotification {
         tag: Some("new_chat_messages".to_string()),
         ..Default::default()
     }
+}
+
+#[inline(always)]
+fn create_apns_config() -> ApnsConfig {
+    ApnsConfig {
+        headers: Some(create_ios_notification()),
+        ..Default::default()
+    }
+}
+
+#[inline(always)]
+fn create_ios_notification() -> HashMap<String, String> {
+    let mut map = HashMap::new();
+    map.insert("apns-collapse-id".to_string(), "new_chat_messages".to_string());
+    map
 }

--- a/fpush/src/xmpp/message_loop.rs
+++ b/fpush/src/xmpp/message_loop.rs
@@ -123,7 +123,7 @@ async fn handle_iq(conn: &mpsc::Sender<Iq>, push_modules: FpushPushArc, stanza: 
                     return;
                 }
             };
-            debug!(
+            warn!(
                 "Selected push_module {} for JID {} with token {}",
                 module_id, from, token
             );

--- a/fpush/src/xmpp/message_loop.rs
+++ b/fpush/src/xmpp/message_loop.rs
@@ -11,7 +11,7 @@ use log::{debug, error, info, warn};
 
 use tokio::sync::mpsc;
 use tokio_xmpp::Component;
-use xmpp_parsers::{iq::Iq, pubsub::PubSub, Element, Jid};
+use xmpp_parsers::{iq::Iq, pubsub::PubSub, Element, data_forms::Field, Jid};
 
 pub(crate) async fn init_component_connection(config: &FpushConfig) -> Result<Component> {
     let component = Component::new(
@@ -180,7 +180,30 @@ fn parse_token_and_module_id(iq_payload: Element) -> Result<(String, String)> {
             PubSub::Publish {
                 publish: pubsub_payload,
                 publish_options: None,
-            } => Ok(("default".to_string(), pubsub_payload.node.0)),
+            } => {
+                // Actual push notifications from prosody have a child value in the
+                // message body of one of the <field> tags, but in some cases
+                // mod_cloud_notify sends unimportant notifications that do not correspond
+                // to unread messages but were getting captured by fpush anyway.
+                // this logic filters out those notifications so they do not reach the user 
+                for item in pubsub_payload.items {
+                    if let Some(payload) = &item.payload {
+                        for form_child in payload.children() {
+                            if let Ok(form) = Element::try_from(form_child.clone()) {
+                                for child in form.children() {
+                                    if let Ok(field) = Field::try_from(child.clone()) {
+                                        if field.var == "last-message-body" && field.values.is_empty() {
+                                            warn!("this is an unimportant notification from mod_cloud_notify, do not send to FCM");
+                                            return Err(Error::PubSubNonPublish);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                Ok(("default".to_string(), pubsub_payload.node.0))
+            },
             PubSub::Publish {
                 publish: pubsub_payload,
                 publish_options: Some(publish_options),


### PR DESCRIPTION
this PR:

- nixifes fpush so it can be deployed in our infra
- adds custom text to the push notification message
- uses tags to make sure multiple push notifications are grouped into 1 when it reaches the device
- filters out unimportant notifications send by prosody

note: the above changes have been live and used since ~ June 2023 but we just never merged this PR to master... the change below is new:

- filters out notifications that explicitly are marked to not notify the recipient